### PR TITLE
- PasswordEncorder 이외의 Spring security의 기능을 사용하지 않도록 설정

### DIFF
--- a/src/main/java/com/somoim/config/WebSecurityConfig.java
+++ b/src/main/java/com/somoim/config/WebSecurityConfig.java
@@ -2,7 +2,7 @@ package com.somoim.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,7 +17,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/users/*");
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .headers().frameOptions().disable();
     }
 }


### PR DESCRIPTION
WebSecurity의 url ignoring 대신 HttpSecurity의 disable()로 Spring security를 사용하지 않도록 처리하였습니다.
 - 기존 /users url에서만 Spring security가 적용되지 않았던 문제