### PR TITLE
63 사용자 모임의 주소 정보 적용

### DIFF
--- a/src/main/java/com/somoim/controller/ProfileController.java
+++ b/src/main/java/com/somoim/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.somoim.controller;
 
 import com.somoim.annotation.LoginCheck;
+import com.somoim.model.dto.UpdateUserProfile;
 import com.somoim.model.dto.UserProfile;
 import com.somoim.service.ProfileService;
 import com.somoim.service.UserService;
@@ -31,7 +32,7 @@ public class ProfileController {
 
     @LoginCheck
     @PutMapping
-    public void updateProfile(@RequestBody UserProfile userProfile) {
-        profileService.updateProfile(userProfile);
+    public void updateProfile(@RequestBody UpdateUserProfile updateUserProfile) {
+        profileService.updateProfile(updateUserProfile);
     }
 }

--- a/src/main/java/com/somoim/mapper/AddressMapper.java
+++ b/src/main/java/com/somoim/mapper/AddressMapper.java
@@ -1,0 +1,12 @@
+package com.somoim.mapper;
+
+import com.somoim.model.dao.Address;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AddressMapper {
+
+	Integer selectRegionIdByAddressId(Integer addressId);
+
+	Address selectAddressString(Integer addressId);
+}

--- a/src/main/java/com/somoim/model/dao/Address.java
+++ b/src/main/java/com/somoim/model/dao/Address.java
@@ -1,0 +1,21 @@
+package com.somoim.model.dao;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+public class Address {
+
+	private Integer id;
+
+	private Integer regionId;
+
+	private String sido;
+
+	private String sigungu;
+
+	private String eupmyundong;
+}

--- a/src/main/java/com/somoim/model/dao/Group.java
+++ b/src/main/java/com/somoim/model/dao/Group.java
@@ -11,14 +11,23 @@ import java.time.LocalDateTime;
 @Builder
 public class Group {
 
-    private Long id;
-    private Long categoryId;
-    private Long imageId;
-    private Integer cityCode1;
-    private Integer cityCode2;
-    private String name;
-    private String detail;
-    private LocalDateTime createAt;
-    private LocalDateTime modifyAt;
-    private Boolean disband;
+	private Long id;
+
+	private Long categoryId;
+
+	private Long imageId;
+
+	private Integer addressId;
+
+	private Integer regionId;
+
+	private String name;
+
+	private String detail;
+
+	private LocalDateTime createAt;
+
+	private LocalDateTime modifyAt;
+
+	private Boolean disband;
 }

--- a/src/main/java/com/somoim/model/dto/UpdateUserProfile.java
+++ b/src/main/java/com/somoim/model/dto/UpdateUserProfile.java
@@ -1,0 +1,28 @@
+package com.somoim.model.dto;
+
+import com.somoim.enumeration.GenderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+public class UpdateUserProfile {
+
+	private Long id;
+
+	private String name;
+
+	private String birth;
+
+	private GenderType gender;
+
+	private Integer addressId;
+
+	private String profileImagePath;
+}

--- a/src/main/java/com/somoim/model/dto/UserProfile.java
+++ b/src/main/java/com/somoim/model/dto/UserProfile.java
@@ -14,10 +14,15 @@ import lombok.Setter;
 @EqualsAndHashCode
 public class UserProfile {
 
-    private Long id;
-    private String name;
-    private String birth;
-    private GenderType gender;
-    private String address;
-    private String profileImagePath;
+	private Long id;
+
+	private String name;
+
+	private String birth;
+
+	private GenderType gender;
+
+	private String address;
+
+	private String profileImagePath;
 }

--- a/src/main/java/com/somoim/service/AddressService.java
+++ b/src/main/java/com/somoim/service/AddressService.java
@@ -1,0 +1,35 @@
+package com.somoim.service;
+
+import com.somoim.exception.NotFoundException;
+import com.somoim.mapper.AddressMapper;
+import com.somoim.model.dao.Address;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+
+	private final AddressMapper addressMapper;
+
+	@Transactional(readOnly = true)
+	public Integer getRegionId(Integer addressId) {
+		Integer regionId = addressMapper.selectRegionIdByAddressId(addressId);
+		if (regionId == 0) {
+			throw new NotFoundException("addressId is invalid");
+		}
+
+		return regionId;
+	}
+
+	@Transactional(readOnly = true)
+	public String getAddress(Integer addressId) {
+		Address address = addressMapper.selectAddressString(addressId);
+		if (address == null) {
+			throw new NotFoundException("addressId is invalid");
+		}
+
+		return address.getSido() + " " + address.getSigungu();
+	}
+}

--- a/src/main/java/com/somoim/service/GroupService.java
+++ b/src/main/java/com/somoim/service/GroupService.java
@@ -13,23 +13,25 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class GroupService {
 
-    private final GroupMapper groupMapper;
+	private final AddressService addressService;
 
-    @Transactional
-    public void createGroup(UpdateGroup updateGroup) {
-        LocalDateTime time = LocalDateTime.now();
+	private final GroupMapper groupMapper;
 
-        Group group = Group.builder()
-                .categoryId(updateGroup.getCategoryId())
-                .imageId(updateGroup.getImageId())
-                .cityCode1(updateGroup.getCityCode1())
-                .cityCode2(updateGroup.getCityCode2())
-                .name(updateGroup.getName())
-                .detail(updateGroup.getDetail())
-                .createAt(time)
-                .modifyAt(time)
-                .disband(false)
-                .build();
-        groupMapper.insertGroup(group);
-    }
+	@Transactional
+	public void createGroup(UpdateGroup updateGroup) {
+		LocalDateTime time = LocalDateTime.now();
+
+		Group group = Group.builder()
+			.categoryId(updateGroup.getCategoryId())
+			.imageId(updateGroup.getImageId())
+			.addressId(updateGroup.getAddressId())
+			.regionId(addressService.getRegionId(updateGroup.getAddressId()))
+			.name(updateGroup.getName())
+			.detail(updateGroup.getDetail())
+			.createAt(time)
+			.modifyAt(time)
+			.disband(false)
+			.build();
+		groupMapper.insertGroup(group);
+	}
 }

--- a/src/main/java/com/somoim/service/ProfileService.java
+++ b/src/main/java/com/somoim/service/ProfileService.java
@@ -3,6 +3,7 @@ package com.somoim.service;
 import com.somoim.exception.NotFoundException;
 import com.somoim.mapper.ProfileMapper;
 import com.somoim.model.dao.User;
+import com.somoim.model.dto.UpdateUserProfile;
 import com.somoim.model.dto.UserProfile;
 
 import java.time.LocalDateTime;
@@ -15,41 +16,41 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProfileService {
 
-    private final ProfileMapper profileMapper;
+	private final AddressService addressService;
 
-    @Transactional
-    public void updateProfile(UserProfile userProfile) {
-        User user = User.builder()
-            .id(userProfile.getId())
-            .name(userProfile.getName())
-            .birth(userProfile.getBirth())
-            .gender(userProfile.getGender())
-            // 주소와 프로필 이미지는 다른 브랜치에서 구현될 예정입니다.
-            .cityCode1(0)
-            .cityCode2(0)
-            .imageId(null)
-            .modifyAt(LocalDateTime.now())
-            .build();
+	private final ProfileMapper profileMapper;
 
-        profileMapper.updateProfile(user);
-    }
+	@Transactional
+	public void updateProfile(UpdateUserProfile updateUserProfile) {
+		User user = User.builder()
+			.id(updateUserProfile.getId())
+			.name(updateUserProfile.getName())
+			.birth(updateUserProfile.getBirth())
+			.gender(updateUserProfile.getGender())
+			.addressId(updateUserProfile.getAddressId())
+			.regionId(addressService.getRegionId(updateUserProfile.getAddressId()))
+			.imageId(null)
+			.modifyAt(LocalDateTime.now())
+			.build();
 
-    @Transactional(readOnly = true)
-    public UserProfile getUserProfile(Long userId) {
-        User user = profileMapper.getProfile(userId);
-        if (user == null) {
-            throw new NotFoundException("User not found");
-        }
-        
-        return UserProfile.builder()
-            .id(userId)
-            .name(user.getName())
-            .birth(user.getBirth())
-            .gender(user.getGender())
-            // 주소와 프로필 이미지는 다른 브랜치에서 구현될 예정입니다.
-            .address("서울시 강남구")
-            .profileImagePath("")
-            .build();
-    }
+		profileMapper.updateProfile(user);
+	}
+
+	@Transactional(readOnly = true)
+	public UserProfile getUserProfile(Long userId) {
+		User user = profileMapper.getProfile(userId);
+		if (user == null) {
+			throw new NotFoundException("User not found");
+		}
+
+		return UserProfile.builder()
+			.id(userId)
+			.name(user.getName())
+			.birth(user.getBirth())
+			.gender(user.getGender())
+			.address(addressService.getAddress(user.getAddressId()))
+			.profileImagePath("")
+			.build();
+	}
 }
 

--- a/src/main/resources/mapper/AddressMapper.xml
+++ b/src/main/resources/mapper/AddressMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.somoim.mapper.AddressMapper">
+  <select id="selectRegionIdByAddressId" parameterType="Integer" resultType="Integer">
+    SELECT region_id
+    FROM address
+    WHERE id = #{addressId}
+  </select>
+
+  <select id="selectAddressString" parameterType="Integer"
+    resultType="com.somoim.model.dao.Address">
+    SELECT sido, sigungu
+    FROM address
+    WHERE id = #{addressId}
+  </select>
+</mapper>

--- a/src/main/resources/seeds/data.sql
+++ b/src/main/resources/seeds/data.sql
@@ -46,3 +46,15 @@ INSERT INTO somoim.member(id, user_id, group_id, role, create_at, modify_at, dis
 VALUES (4, 4, 1, 'MEMBER', SYSDATE(), SYSDATE(), false); -- user4는 group01의 멤버
 INSERT INTO somoim.member(id, user_id, group_id, role, create_at, modify_at, disband)
 VALUES (5, 5, 2, 'MEMBER', SYSDATE(), SYSDATE(), false); -- user5는 group02의 멤버
+
+-- 주소 sample
+INSERT INTO somoim.address(id, region_id, sido, sigungu, eupmyundong)
+VALUES (1, 1, "서울특별시", "강남구", "수서동");
+INSERT INTO somoim.address(id, region_id, sido, sigungu, eupmyundong)
+VALUES (2, 1, "서울특별시", "강남구", "삼성동");
+INSERT INTO somoim.address(id, region_id, sido, sigungu, eupmyundong)
+VALUES (3, 2, "서울특별시", "성동구", "성수동");
+INSERT INTO somoim.address(id, region_id, sido, sigungu, eupmyundong)
+VALUES (4, 3, "인천광역시", "연수구", "송도동");
+INSERT INTO somoim.address(id, region_id, sido, sigungu, eupmyundong)
+VALUES (5, 4, "경기도", "성남시 분당구", "운중동");

--- a/src/main/resources/seeds/schema.sql
+++ b/src/main/resources/seeds/schema.sql
@@ -178,3 +178,15 @@ CREATE TABLE IF NOT EXISTS `somoim`.`comment`
             ON DELETE NO ACTION
             ON UPDATE NO ACTION
 ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `somoim`.`address`
+(
+    `id`            INT         NOT NULL AUTO_INCREMENT,
+    `region_id`     INT         NOT NULL,
+    `sido`          VARCHAR(40) NOT NULL,
+    `sigungu`       VARCHAR(40) NOT NULL,
+    `eupmyundong`   VARCHAR(40) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `ix_sigungu_id` (`region_id`),
+    KEY `ix_address` (`sido`, `sigungu`, `eupmyundong`)
+) ENGINE = InnoDB;

--- a/src/test/java/com/somoim/service/AddressServiceTest.java
+++ b/src/test/java/com/somoim/service/AddressServiceTest.java
@@ -1,0 +1,70 @@
+package com.somoim.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.somoim.exception.NotFoundException;
+import com.somoim.mapper.AddressMapper;
+import com.somoim.model.dao.Address;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AddressServiceTest {
+
+	@InjectMocks
+	AddressService addressService;
+
+	@Mock
+	AddressMapper addressMapper;
+
+	Address address;
+
+	@BeforeEach
+	void setUp() {
+		address = Address.builder()
+			.id(1)
+			.regionId(1)
+			.sido("서울특별시")
+			.sigungu("강남구")
+			.eupmyundong("수서동")
+			.build();
+	}
+
+	@Test
+	void getRegionIdTestWithSuccess() {
+		Integer addressId = address.getId();
+		Integer regionId = address.getRegionId();
+
+		when(addressMapper.selectRegionIdByAddressId(addressId))
+			.thenReturn(regionId);
+		assertThat(regionId, is(equalTo(addressService.getRegionId(addressId))));
+	}
+
+	@Test
+	void getRegionIdTestWithFail() {
+		assertThrows(NotFoundException.class, () -> addressService.getRegionId(1));
+	}
+
+	@Test
+	void getAddressWithSuccess() {
+		when(addressMapper.selectAddressString(address.getId()))
+			.thenReturn(address);
+
+		String expected = address.getSido() + " " + address.getSigungu();
+		String result = addressService.getAddress(address.getId());
+		assertThat(result, is(equalTo(expected)));
+	}
+
+	@Test
+	void getAddressWithFail() {
+		assertThrows(NotFoundException.class, () -> addressService.getAddress(1));
+	}
+}

--- a/src/test/java/com/somoim/service/GroupServiceTest.java
+++ b/src/test/java/com/somoim/service/GroupServiceTest.java
@@ -11,26 +11,32 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GroupServiceTest {
 
-    @InjectMocks
-    GroupService groupService;
+	@InjectMocks
+	GroupService groupService;
 
-    @Mock
-    GroupMapper groupMapper;
+	@Mock
+	AddressService addressService;
 
-    @Test
-    void createGroup() {
+	@Mock
+	GroupMapper groupMapper;
 
-        UpdateGroup updateGroup = new UpdateGroup();
-        updateGroup.setName("testGroup");
-        updateGroup.setCategoryId(1L);
-        updateGroup.setCityCode1(0);
+	@Test
+	void createGroup() {
 
-        groupService.createGroup(updateGroup);
+		UpdateGroup updateGroup = new UpdateGroup();
+		updateGroup.setName("testGroup");
+		updateGroup.setCategoryId(1L);
+		updateGroup.setAddressId(1);
 
-        verify(groupMapper).insertGroup(any(Group.class));
-    }
+		when(addressService.getRegionId(1))
+			.thenReturn(1);
+		groupService.createGroup(updateGroup);
+
+		verify(groupMapper).insertGroup(any(Group.class));
+	}
 }

--- a/src/test/java/com/somoim/service/ProfileServiceTest.java
+++ b/src/test/java/com/somoim/service/ProfileServiceTest.java
@@ -11,6 +11,7 @@ import com.somoim.enumeration.GenderType;
 import com.somoim.exception.NotFoundException;
 import com.somoim.mapper.ProfileMapper;
 import com.somoim.model.dao.User;
+import com.somoim.model.dto.UpdateUserProfile;
 import com.somoim.model.dto.UserProfile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,19 +27,32 @@ public class ProfileServiceTest {
     ProfileService profileService;
 
     @Mock
+    AddressService addressService;
+
+    @Mock
     ProfileMapper profileMapper;
 
+    UpdateUserProfile updateUserProfile;
     UserProfile userProfile;
     User user;
 
     @BeforeEach
     void setUp() {
+        updateUserProfile = UpdateUserProfile.builder()
+            .id(1L)
+            .name("test01")
+            .birth("2000-01-01")
+            .gender(GenderType.M)
+            .addressId(1)
+            .profileImagePath("")
+            .build();
+
         userProfile = UserProfile.builder()
             .id(1L)
             .name("test01")
             .birth("2000-01-01")
             .gender(GenderType.M)
-            .address("서울시 강남구")
+            .address("서울특별시 강남구")
             .profileImagePath("")
             .build();
 
@@ -47,15 +61,15 @@ public class ProfileServiceTest {
             .name("test01")
             .birth("2000-01-01")
             .gender(GenderType.M)
-            .cityCode1(0)
-            .cityCode2(0)
+            .addressId(1)
+            .regionId(1)
             .imageId(0L)
             .build();
     }
 
     @Test
     void updateProfileTest() {
-        profileService.updateProfile(userProfile);
+        profileService.updateProfile(updateUserProfile);
         verify(profileMapper).updateProfile(any(User.class));
     }
 
@@ -63,6 +77,8 @@ public class ProfileServiceTest {
     void getUserProfileTest() {
         when(profileMapper.getProfile(1L))
             .thenReturn(user);
+        when(addressService.getAddress(1))
+            .thenReturn("서울특별시 강남구");
         UserProfile testProfile = profileService.getUserProfile(1L);
         assertThat(testProfile, is(equalTo(userProfile)));
     }


### PR DESCRIPTION
주소 정보 서비스를 구현했습니다.

* 주소 테이블
  * 시군구를 기준으로 region_id가 부여됩니다.
  * region_id를 기준으로 사용자와 그룹이 매칭됩니다.

id | region_id | sido | sigungu | eupmyundong
---- | ---- | ---- | ---- | ----
1 | 1 | 서울특별시 | 강남구 | 수서동
2 | 1 | 서울특별시 | 강남구 | 삼성동
3 | 2 | 인천광역시 | 연수구 | 송도동
4 | 3 | 경기도 | 성남시 분당구 | 판교동
5 | 3 | 경기도 | 성남시 분당구 | 정자동